### PR TITLE
Added support for use of hwrng and array sources

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,15 +1,16 @@
 ---
 driver:
   name: vagrant
+  cache_directory: false
   vagrantfile_erb: Vagrantfile.erb
 
 provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-5.11
-  - name: centos-6.6
-  - name: centos-7.0
+  - name: centos5
+  - name: centos6
+  - name: centos7
   - name: fedora-20
   - name: debian-7.8
   - name: debian-8.1
@@ -20,7 +21,19 @@ platforms:
   - name: ubuntu-14.04
 
 suites:
-
   - name: default
     run_list:
       - recipe[rngd-tools::default]
+  - name: hwrng
+    run_list:
+      - recipe[rngd-tools::default]
+    attributes:
+      rng-tools:
+        use_hwrng: true
+  - name: dynamic_no_hwrng
+    run_list:
+      - recipe[rngd-tools::default]
+    attributes:
+      rng-tools:
+        use_hwrng: false
+        dynamic: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.0:
+
+* Added support for an array of sources (requires an attribute to be `true`)
+* Added support to use hwrng (from intel cpus, also requires an attribute to be set to `true`)
+   * hwrng only tested in vsphere and aws with CentOS 7.x
+
 ## v1.3.0:
 
 * Add RHEL/CentOS 5 Support

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Attributes
 ==========
 
 * `node['rng_tools']['device']` - the device to use for random data. default /dev/urandom
+* `node['rng_tools']['devices']` - array of devices, uses first found, when `dynamic` set to `true`
+* `node['rng_tools']['dynamic']` - Boolean `true,false`, default: `false`, whether to use `devices` array
+* `node['rng_tools']['use_hwrng']` - Boolean `true,false`, default `false`, whether to use hwrng if present (currently Intel CPU only)
 
 Usage
 =====
@@ -30,10 +33,11 @@ The rng-tools.default template will use the device in the attribute. This is a n
 License and Author
 ==================
 
-Author:: Joshua Timberman (<cookbooks@housepub.org>), Brian Flad (<bflad417@gmail.com>), Ovais Tariq (me@ovaistariq.net)
+Author:: Joshua Timberman (<cookbooks@housepub.org>), Brian Flad (<bflad417@gmail.com>), Ovais Tariq (me@ovaistariq.net), Wade Peacock (wade.peacock@visioncritical.com)
 
 Copyright 2012, Joshua Timberman, Brian Flad
 Copyright 2015, Ovais Tariq
+Copyright 2017, Wade Peacock
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,10 @@
 # Attributes:: default
 #
 
-default['rng_tools']['device'] = "/dev/urandom"
+default['rng_tools']['device'] = '/dev/urandom' # Specific device to use if dynamic is false
+default['rng_tools']['dynamic'] = false # Use 1st device from devices array
+default['rng_tools']['devices'] = %w( /dev/hwrng /dev/hw_random /dev/hwrandom /dev/urandom )
+default['rng_tools']['use_hwrng'] = false # Use hardware device if present in CPU
 
 if node["platform_family"] == "rhel" and node["platform_version"].to_i < 6
   default['rng_tools']['package'] = "rng-utils"

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,24 @@
+module RndgTools
+  module Helpers
+    def hwrng?
+      node['cpu']['0']['flags'].include?('rdrand')
+    end
+
+    def rng_device
+      case node['rng_tools']['dynamic']
+      when true
+        node['rngd-tools']['devices'].each do |device|
+          if ::File.chardev?(device)
+            Chef::Log.info("Using #{node['rng_tools']['device']} as an entropy source")
+            return device
+          end
+        end
+      when false
+        node['rngd-tools']['device']
+      end
+    end
+  end
+end
+
+Chef::Recipe.send(:include, RndgTools::Helpers)
+Chef::Resource.send(:include, RndgTools::Helpers)

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "me@ovaistariq.net"
 license          "Apache 2.0"
 description      "Installs/Configures rng-tools"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.3.0"
+version          "2.0.0"
 
 %w{ centos fedora amazon redhat debian ubuntu }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,6 +4,7 @@
 #
 # Copyright 2011, Joshua Timberman
 # Copyright 2015, Ovais Tariq
+# Copyright 2017, Wade Peacock
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +40,15 @@ when "fedora", "rhel"
     notifies :restart, "service[rng-tools]", :immediately
     only_if { node["platform_version"].to_f >= 7.0 }
     only_if { node["platform"] != "amazon" }
+    not_if { node['rng_tools']['use_hwrng'] && hwrng? }
   end
+
+  file '/etc/systemd/system/rngd.service' do
+    action :delete
+    notifies :run, "bash[reload-systemd-daemon]", :immediately
+    notifies :restart, "service[rng-tools]", :immediately
+    only_if { node['rng_tools']['use_hwrng'] && hwrng? }
+  end 
 
   template "/etc/init.d/rngd" do
     source "sysvinit/rngd.service.erb"


### PR DESCRIPTION
defaults to specific device to preserve backward/legacy default

Introduced 3 new attributes.
  rng-tools/devices (Array)
  rng-tools/dynamic (Boolean: true/false default: false)
  rng-tools/use_hwrng (Boolean: true/false default: false)

Updated docs